### PR TITLE
If in Development allow logout, so the app can be navigated naturally.

### DIFF
--- a/app/screens/ho-profile/HomeownerProfileScreen.tsx
+++ b/app/screens/ho-profile/HomeownerProfileScreen.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/prefer-as-const */
 import * as React from "react"
-import { View, StyleSheet, StatusBar, Platform } from "react-native"
+import { View, StyleSheet, StatusBar, Platform, Text, TouchableOpacity } from "react-native"
 import { StackScreenProps } from "@react-navigation/stack"
 import MapView from "react-native-maps"
 
@@ -20,6 +20,10 @@ const styles = StyleSheet.create({
   divider: {
     marginBottom: 32,
     marginTop: 32,
+  },
+  logoutText: {
+    color: color.palette.warn,
+    marginTop: 15,
   },
   map: {
     flex: 1,
@@ -45,6 +49,7 @@ export const HomeownerProfileScreen: React.FC<
 > = observer(() => {
   const {
     userStore: { user },
+    userStore,
   } = useStores()
 
   const geo = React.useMemo(
@@ -54,6 +59,10 @@ export const HomeownerProfileScreen: React.FC<
     }),
     [user.location.coords],
   )
+
+  const handleLogoutPress = React.useCallback(() => {
+    userStore.saveIsLoggedIn(false)
+  }, [userStore])
 
   return (
     <View style={styles.container}>
@@ -92,6 +101,11 @@ export const HomeownerProfileScreen: React.FC<
             count: user.location.nrBeds || 1,
           })}
         />
+        {__DEV__ && (
+          <TouchableOpacity onPress={handleLogoutPress}>
+            <Text style={styles.logoutText}>Logout</Text>
+          </TouchableOpacity>
+        )}
       </View>
     </View>
   )


### PR DESCRIPTION
Allow the app to be naturally. navigated by logging out if in development.
Having to move around navigators and stuff to work on a page is annoying.

<img width="397" alt="Screen Shot 2022-03-14 at 12 44 39 AM" src="https://user-images.githubusercontent.com/22606146/158126851-5173acae-05d9-43af-bedb-0d50fdea6c51.png">
<img width="401" alt="Screen Shot 2022-03-14 at 12 44 44 AM" src="https://user-images.githubusercontent.com/22606146/158126861-a063890b-4d6c-4a0e-bcd8-55626c0913bb.png">

